### PR TITLE
Reduce size of Micr text

### DIFF
--- a/src/static/all.css
+++ b/src/static/all.css
@@ -174,15 +174,15 @@
 
 .check .bank-account-info {
     font-family: 'MICR';
-    font-size: 80px;
-    line-height: 80px;
-    padding: 0 50px;
+    font-size: 65px;
+    line-height: 65px;
+    padding: 0 30px;
     border-radius: 10px;
     background-color: rgba(255,255,255,0.5);
 }
 
 .check .bank-account-info .routing-number {
-    margin-right: 100px;
+    margin-right: 50px;
 }
 
 .check .check-info,


### PR DESCRIPTION
Bank was rejecting mobile deposit saying it could not read the numbers at the bottom of the check.
Resolved the issue after comparing with a regular bank issued check.  The Micr font was too large.
Reduced font size approx 19% and adjusted margin/padding to put the Micr more to the left of the check.
Mobile deposit worked with no problem after the change.


See before and after example below:

![image](https://user-images.githubusercontent.com/47253594/123116421-83bc9a80-d406-11eb-84bb-fe7543bfd982.png)

![image](https://user-images.githubusercontent.com/47253594/123115741-f0836500-d405-11eb-9306-50adf922073f.png)

